### PR TITLE
Add Spring '19 new values for scratch org features

### DIFF
--- a/project-scratch-def.json/project-scratch-def.schema.json
+++ b/project-scratch-def.json/project-scratch-def.schema.json
@@ -83,12 +83,16 @@
               "ContactsToMultipleAccounts",
               "ContractApprovals",
               "CascadeDelete",
+              "ChatterAnswers",
               "CustomerSelfService",
               "CustomApps",
+              "CustomNotificationType",
               "CustomTabs",
               "DebugApex",
               "DefaultWorkflowUser",
+              "DevelopmentWave",
               "Entitlements",
+              "EinsteinAssistant",
               "ExternalSharing",
               "ForceComPlatform",
               "Interaction",
@@ -101,6 +105,7 @@
               "MaxApexCodeSize:<value>",
               "MaxCustomLabels:<value>",
               "MultiCurrency",
+              "Pardot",
               "PersonAccounts",
               "ProcessBuilder",
               "SalesWave",
@@ -110,6 +115,8 @@
               "SiteForceContributor",
               "Sites",
               "StateAndCountryPicklist",
+              "TerritoryManagement",
+              "TimeSheetTemplateSettings",
               "Workflow"
             ]
           }

--- a/project-scratch-def.json/project-scratch-def.schema.json
+++ b/project-scratch-def.json/project-scratch-def.schema.json
@@ -117,6 +117,7 @@
               "StateAndCountryPicklist",
               "TerritoryManagement",
               "TimeSheetTemplateSettings",
+              "UiPlugin",              
               "Workflow"
             ]
           }


### PR DESCRIPTION
Adding new values for scratch org  [features from Spring '19](http://docs.releasenotes.salesforce.com/en-us/spring19/release-notes/rn_scratch_org_features.htm). Except for `UiPlugin`, which doesn't work (reported [here](https://success.salesforce.com/0D53A00004MqFIG)). Also note that `CustomNotificationType` is misspelled in the release notes (but is correct in the [official docs](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_scratch_orgs_def_file_config_values.htm) ).