### PR TITLE
Update scrach org features list for Summer '19

### DIFF
--- a/project-scratch-def.json/project-scratch-def.schema.json
+++ b/project-scratch-def.json/project-scratch-def.schema.json
@@ -7,16 +7,36 @@
   "required": ["edition"],
   "additionalProperties": true,
   "properties": {
-    "orgName": { "$ref": "#/definitions/orgName" },
-    "edition": { "$ref": "#/definitions/edition" },
-    "country": { "$ref": "#/definitions/country" },
-    "username": { "$ref": "#/definitions/username" },
-    "adminEmail": { "$ref": "#/definitions/adminEmail" },
-    "description": { "$ref": "#/definitions/description" },
-    "hasSampleData": { "$ref": "#/definitions/hasSampleData" },
-    "language": { "$ref": "#/definitions/language" },
-    "features": { "$ref": "#/definitions/features" },
-    "template": { "$ref": "#/definitions/template" },
+    "orgName": {
+      "$ref": "#/definitions/orgName"
+    },
+    "edition": {
+      "$ref": "#/definitions/edition"
+    },
+    "country": {
+      "$ref": "#/definitions/country"
+    },
+    "username": {
+      "$ref": "#/definitions/username"
+    },
+    "adminEmail": {
+      "$ref": "#/definitions/adminEmail"
+    },
+    "description": {
+      "$ref": "#/definitions/description"
+    },
+    "hasSampleData": {
+      "$ref": "#/definitions/hasSampleData"
+    },
+    "language": {
+      "$ref": "#/definitions/language"
+    },
+    "features": {
+      "$ref": "#/definitions/features"
+    },
+    "template": {
+      "$ref": "#/definitions/template"
+    },
     "settings": {
       "$ref": "#/definitions/settings"
     }
@@ -73,51 +93,80 @@
           {
             "type": "string",
             "enum": [
+              "ActionPlans",
               "AddCustomApps:<value>",
+              "AddCustomObjects:<value>",
+              "AddCustomRelationships:<value>",
               "AddCustomTabs:<value>",
+              "AddDatacomCrmRecordCredit:<value>",
+              "AddInsightsQueryLimit:<value>",
               "AddHistoryFieldsPerEntity:<value>",
+              "AnalyticsAdminPerms",
               "API",
               "AuthorApex",
+              "CascadeDelete",
               "Chatbot",
+              "ChatterAnswers",
+              "ChatterAnswersUser",
               "Communities",
               "ContactsToMultipleAccounts",
               "ContractApprovals",
-              "CascadeDelete",
-              "ChatterAnswers",
+              "CPQ",
               "CustomerSelfService",
-              "CustomApps",
               "CustomNotificationType",
-              "CustomTabs",
+              "DatacomDnbAccounts",
+              "DatacomFullClean",
               "DebugApex",
               "DefaultWorkflowUser",
+              "DeferSharingCalc",
               "DevelopmentWave",
-              "Entitlements",
+              "EinsteinAnalyticsPlus",
               "EinsteinAssistant",
+              "EinsteinBuilder",
+              "Entitlements",
+              "EventLogFile",
+              "ExternalIdentityLogin",
               "ExternalSharing",
+              "FieldService",
+              "FlowSites",
               "ForceComPlatform",
+              "HealthCloudUser",
+              "IndustriesManufacturing",
+              "InsightsPlatform",
               "Interaction",
               "IoT",
+              "JigsawUser",
               "Knowledge",
               "LightningSalesConsole",
               "LightningServiceConsole",
               "LiveAgent",
               "LiveMessage",
+              "MarketingUser",
               "MaxApexCodeSize:<value>",
               "MaxCustomLabels:<value>",
+              "MobileUser",
               "MultiCurrency",
+              "OfflineUser",
               "Pardot",
               "PersonAccounts",
+              "PlatformCache",
+              "PlatformEncryption",
               "ProcessBuilder",
-              "SalesWave",
+              "ProductsAndSchedules",
+              "RecordTypes",
+              "RetainFieldHistory",
+              "SalesUser",
               "ServiceCloud",
-              "ServiceWave",
+              "ServiceUser",
               "SiteDotCom",
               "SiteForceContributor",
               "Sites",
               "StateAndCountryPicklist",
-              "TerritoryManagement",
+              "SurveyCreatorUser",
+              "TerritoryManagement2",
               "TimeSheetTemplateSettings",
-              "UiPlugin",              
+              "UiPlugin",
+              "WavePlatform",
               "Workflow"
             ]
           }


### PR DESCRIPTION
From https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_scratch_orgs_def_file_config_values.htm and https://releasenotes.docs.salesforce.com/en-us/summer19/release-notes/rn_scratch_orgs_features.htm.

`SalesWave` and `ServiceWave` are being deprecated, and it looks like `CustomApps` and `CustomTabs` were deprecated in Spring '19 but not removed here. And `TerritoryManagement` must have been deprecated at some point, although I can't see when. If this list should include deprecated ones, I can add them back in.

In Einstein Analytics, we're going to start telling people to use `EinsteinAnalyticsPlus` and `AnalyticsAdminPerms` pretty soon here, as 220 becomes available, but we can sit on this until then if you want.