### PR TITLE
chore: add restricted context for publish workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,7 @@ workflows:
       - hold: # Requires manual approval in Circle Ci
           type: approval
       - publish:
+          context: pdt-publish-restricted-context
           filters:
             branches:
               only:


### PR DESCRIPTION
### What does this PR do?
Adds the team 'PDT' from GitHub as the required group for the publish workflow. This will mean anyone from forcedotcom can 'approve' the publish job, however it should fail due to authentication once it reaches the publish step. Only if the approver is from 'PDT' should the publish job proceed.

### Resource
[Approving Jobs that Use Restricted Contexts](https://circleci.com/docs/2.0/contexts/#approving-jobs-that-use-restricted-contexts)

### What issues does this PR fix or reference?
@W-8165486@