### PR TITLE
feat(sfdx-project): add name property to project schema

### DIFF
--- a/examples/sfdx-project/default.json
+++ b/examples/sfdx-project/default.json
@@ -1,4 +1,5 @@
 {
+  "name": "project-name",
   "packageDirectories": [
     {
       "path": "force-app",

--- a/examples/sfdx-project/min.json
+++ b/examples/sfdx-project/min.json
@@ -1,4 +1,5 @@
 {
+  "name": "project-name",
   "packageDirectories": [
     {
       "path": "force-app",

--- a/examples/sfdx-project/package-basic.json
+++ b/examples/sfdx-project/package-basic.json
@@ -1,4 +1,5 @@
 {
+  "name": "project-name",
   "packageDirectories": [
     {
       "path": "force-app",

--- a/examples/sfdx-project/package-complex.json
+++ b/examples/sfdx-project/package-complex.json
@@ -1,4 +1,5 @@
 {
+  "name": "project-name",
   "namespace": "exp-mgr",
   "sfdcLoginUrl": "https://login.salesforce.com",
   "sourceApiVersion": "47.0",

--- a/examples/sfdx-project/package-no-path-invalid.json
+++ b/examples/sfdx-project/package-no-path-invalid.json
@@ -1,4 +1,5 @@
 {
+  "name": "project-name",
   "packageDirectories": [
     {
       "default": true

--- a/examples/sfdx-project/package-no-versionNumber-invalid.json
+++ b/examples/sfdx-project/package-no-versionNumber-invalid.json
@@ -1,4 +1,5 @@
 {
+  "name": "project-name",
   "packageDirectories": [
     {
       "path": "force-app",

--- a/sfdx-project.schema.json
+++ b/sfdx-project.schema.json
@@ -85,6 +85,11 @@
         }
       }
     },
+    "name": {
+      "title": "name",
+      "type": "string",
+      "description": "The name of your Salesforce project."
+    },
     "namespace": {
       "title": "Namespace",
       "type": "string",


### PR DESCRIPTION
### What does this PR do?

Adds a name property to the `sfdx-project.json` schema

### What issues does this PR fix or reference?

https://gus.lightning.force.com/one/one.app#/alohaRedirect/a07AH0000009lOcYAI

### Functionality Before

### Functionality After

Should be no different except that the name field is documented.
