### PR TITLE
feat: allow branch specification for package directories and package …

### DIFF
--- a/sfdx-project.schema.json
+++ b/sfdx-project.schema.json
@@ -85,6 +85,9 @@
           },
           "versionNumber": {
             "$ref": "#/definitions/packageDirectory.versionNumber"
+          },
+          "branch": {
+            "$ref": "#/definitions/packageDirectory.branch"
           }
         }
       }
@@ -186,6 +189,9 @@
           },
           "versionNumber": {
             "type": "string"
+          },
+          "branch": {
+            "type": "string"
           }
         }
       }
@@ -286,6 +292,11 @@
           ]
         }
       }
+    },
+    "packageDirectory.branch": {
+      "type": "string",
+      "title": "Branch",
+      "description": "The name of the branch to be assigned to the package version"
     }
   }
 }


### PR DESCRIPTION
…dependencies

### What does this PR do?

Migrate schema that was checked into internal schema (W-9191272) to the public schema. The migrated schema allows users to specify a branch in packageDirectories and in package dependencies.

### What issues does this PR fix or reference?

@W-8794784@

### Functionality Before

Users could not supply the branch property.

### Functionality After

Users can supply the branch property in two places:

```
        {
            "path": "app_component_removal",
            "package": "DeleteComponents",
            "versionName": "ver 0.1",
            "versionNumber": "0.1.0.NEXT",
            **"branch": "charlie",**
            "default": false
        },
        {
            "path": "common",
            "package": "common",
            "versionName": "ver 0.1",
            "versionNumber": "0.1.0.NEXT",
            "dependencies": [
                {
                    "package": "branchtest",
                    "versionNumber": "0.1.0.RELEASED",
                    **"branch": "charlie",**
                }
            ],
            "default": false
        },
```
