### PR TITLE
feat: pushPackageDirectoriesSequentially

### DIFF
--- a/sfdx-project.schema.json
+++ b/sfdx-project.schema.json
@@ -5,7 +5,9 @@
   "description": "The properties and shape of the SFDX project",
   "type": "object",
   "additionalProperties": false,
-  "required": ["packageDirectories"],
+  "required": [
+    "packageDirectories"
+  ],
   "properties": {
     "packageDirectories": {
       "title": "Package Directories",
@@ -17,22 +19,64 @@
       "items": {
         "type": "object",
         "dependencies": {
-          "ancestorId": ["package", "versionNumber"],
-          "ancestorVersion": ["package", "versionNumber"],
-          "apexTestAccess": ["package", "versionNumber"],
-          "definitionFile": ["package", "versionNumber"],
-          "dependencies": ["package", "versionNumber"],
-          "package": ["versionNumber"],
-          "postInstallScript": ["package", "versionNumber"],
-          "postInstallUrl": ["package", "versionNumber"],
-          "releaseNotesUrl": ["package", "versionNumber"],
-          "uninstallScript": ["package", "versionNumber"],
-          "unpackagedMetadata": ["package", "versionNumber"],
-          "versionDescription": ["package", "versionNumber"],
-          "versionName": ["package", "versionNumber"],
-          "versionNumber": ["package"]
+          "ancestorId": [
+            "package",
+            "versionNumber"
+          ],
+          "ancestorVersion": [
+            "package",
+            "versionNumber"
+          ],
+          "apexTestAccess": [
+            "package",
+            "versionNumber"
+          ],
+          "definitionFile": [
+            "package",
+            "versionNumber"
+          ],
+          "dependencies": [
+            "package",
+            "versionNumber"
+          ],
+          "package": [
+            "versionNumber"
+          ],
+          "postInstallScript": [
+            "package",
+            "versionNumber"
+          ],
+          "postInstallUrl": [
+            "package",
+            "versionNumber"
+          ],
+          "releaseNotesUrl": [
+            "package",
+            "versionNumber"
+          ],
+          "uninstallScript": [
+            "package",
+            "versionNumber"
+          ],
+          "unpackagedMetadata": [
+            "package",
+            "versionNumber"
+          ],
+          "versionDescription": [
+            "package",
+            "versionNumber"
+          ],
+          "versionName": [
+            "package",
+            "versionNumber"
+          ],
+          "versionNumber": [
+            "package"
+          ]
         },
-        "required": ["path"],
+        "required": [
+          "path"
+        ],
         "additionalProperties": false,
         "properties": {
           "ancestorId": {
@@ -41,7 +85,7 @@
           "ancestorVersion": {
             "$ref": "#/definitions/packageDirectory.ancestorVersion"
           },
-          "apexTestAccess" : {
+          "apexTestAccess": {
             "$ref": "#/definitions/packageDirectory.apexTestAccess"
           },
           "default": {
@@ -122,6 +166,10 @@
       "type": "number",
       "description": "By default, the OAuth port is 1717. However, change this port if this port is already in use, and you plan to create a connected app in your Dev Hub org to support JWT-based authorization."
     },
+    "pushPackageDirectoriesSequentially": {
+      "type": "boolean",
+      "description": "Whether to push package directories sequentially. If true, the package directories are pushed in the order they are listed in the project file. By default, the package directories are pushed in one deployment."
+    },
     "plugins": {
       "title": "CLI Plugins custom settings",
       "type": "object",
@@ -182,7 +230,9 @@
       "description": "To specify dependencies for 2GP within the same Dev Hub, use either the package version alias or a combination of the package name and the version number.",
       "items": {
         "type": "object",
-        "required": ["package"],
+        "required": [
+          "package"
+        ],
         "properties": {
           "package": {
             "type": "string"
@@ -230,7 +280,9 @@
       "type": "object",
       "title": "Unpackaged Metadata",
       "description": "Metadata not meant to be packaged, but deployed when testing packaged metadata",
-      "required": ["path"],
+      "required": [
+        "path"
+      ],
       "properties": {
         "path": {
           "type": "string",


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
@W-10146239@
https://github.com/forcedotcom/cli/issues/1269

### Functionality Before
source:beta:push uses SDR, which handles MPD in one deployment

### Functionality After
customers can set the project to deploy one directory at a time, in order, where SDR's behavior is unwanted.