### PR TITLE
feat(scratch-def): add 'release' to schema properties for autocomplete

### DIFF
--- a/examples/project-scratch-def/with-release.json
+++ b/examples/project-scratch-def/with-release.json
@@ -1,0 +1,6 @@
+{
+  "orgName": "Dreamhouse",
+  "edition": "Developer",
+  "hasSampleData": false,
+  "release": "preview"
+}

--- a/project-scratch-def.schema.json
+++ b/project-scratch-def.schema.json
@@ -17,7 +17,8 @@
     "language": { "$ref": "#/definitions/language" },
     "features": { "$ref": "#/definitions/features" },
     "template": { "$ref": "#/definitions/template" },
-    "settings": { "$ref": "#/definitions/settings" }
+    "settings": { "$ref": "#/definitions/settings" },
+    "release": { "$ref": "#/definitions/release" }
   },
   "definitions": {
     "orgName": {


### PR DESCRIPTION
### What does this PR do?

Adds `release` property to `properties` section of `project-scratch-def.schema.json` so that Visual Studio Code will autocomplete and validate that property.

### What issues does this PR fix or reference?

Although `release` exists in the `definitions` section of `project-scratch-def.schema.json`, Visual Studio Code doesn't autocomplete or provide content-assist for that property in scratch org definition files _because_ it's not listed in the `properties` section, too.

### Functionality Before

_No autocomplete_
![image](https://user-images.githubusercontent.com/4142577/164573080-a14aa9e1-c2e6-4f3f-aca8-61ba0266a5f8.png)

_No validation_
![image](https://user-images.githubusercontent.com/4142577/164573240-aa2891e8-57ad-4e1b-ba38-a42452036bba.png)


### Functionality After

_Autocomplete_
![image](https://user-images.githubusercontent.com/4142577/164572918-e8a0a82d-1ea6-4523-b577-256667581adb.png)

_Validation_
![image](https://user-images.githubusercontent.com/4142577/164572835-1932d6e6-e74d-4e0b-a2ed-430559bc9d05.png)

### How to Test

On my local machine I replaced `~/.vscode/extensions/salesforce.salesforcedx-vscode-core-54.9.0/node_modules/@salesforce/schemas/project-scratch-def.schema.json` with the version in this pull request then restarted Visual Studio Code.