### PR TITLE
feat(scratch-def): add 'release' to schema properties for autocomplete

### DIFF
--- a/examples/project-scratch-def/with-release.json
+++ b/examples/project-scratch-def/with-release.json
@@ -1,0 +1,6 @@
+{
+  "orgName": "Dreamhouse",
+  "edition": "Developer",
+  "hasSampleData": false,
+  "release": "preview"
+}

--- a/project-scratch-def.schema.json
+++ b/project-scratch-def.schema.json
@@ -17,7 +17,8 @@
     "language": { "$ref": "#/definitions/language" },
     "features": { "$ref": "#/definitions/features" },
     "template": { "$ref": "#/definitions/template" },
-    "settings": { "$ref": "#/definitions/settings" }
+    "settings": { "$ref": "#/definitions/settings" },
+    "release": { "$ref": "#/definitions/release" }
   },
   "definitions": {
     "orgName": {


### PR DESCRIPTION
### What does this PR do?
-- Adds release property to properties section of project-scratch-def.schema.json so that Visual Studio Code will autocomplete and validate that property. --

A community contribution from @douglascayers.  See PR #46 for more detail.

### What issues does this PR fix or reference?

#<Insert GitHub Issue>, @<Insert GUS WI>@

### Functionality Before

<insert gif and/or summary>

### Functionality After

<insert gif and/or summary>
