### PR TITLE
chore: update publish context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,9 @@ workflows:
       - hold: # Requires manual approval in Circle Ci
           type: approval
       - publish:
-          context: pdt-publish-restricted-context
+          context: 
+            - pdt-publish-restricted-context
+            - salesforce-cli
           filters:
             branches:
               only:


### PR DESCRIPTION
### What does this PR do?
Updates the publish context in order to include the correct NPM_Token for publishing.