### PR TITLE
chore: update publish to preferred org context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,8 +150,7 @@ workflows:
           type: approval
       - publish:
           context: 
-            - pdt-publish-restricted-context
-            - salesforce-cli
+            - IEAT_keys
           filters:
             branches:
               only:


### PR DESCRIPTION
### What does this PR do?
After reviewing the salesforce-cli context, we're missing an email there to be able to push back to main. I've updated the context to be consistent with the rest of our projects.