### PR TITLE
chore: update ssh for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ _refs:
       - image: node:12
   ssh-config: &ssh-config
     fingerprints:
-      - "b9:23:16:10:0e:93:d1:68:0e:76:4e:90:a0:ed:01:a5"
+      - "d5:4c:63:55:4f:05:be:17:ef:97:65:06:60:e8:4d:92"
   restore_cache: &restore_cache
     keys:
       - v1-npm-{{checksum ".circleci/config.yml"}}-{{checksum "package.json"}}
@@ -66,21 +66,21 @@ jobs:
             - ~/cli/node_modules
 
   build-artifact:
-    description: 'Building and archiving tarball'
+    description: "Building and archiving tarball"
     <<: *defaults
     steps:
-        - checkout
-        - restore_cache: *restore_cache
-        - run: *install
-        - run: npm pack
-        - run:
-            name: Staging artifact
-            command: |
-                mkdir artifact
-                find . -name "*.tgz" -type f -exec cp {} ./artifact \;
-        - store_artifacts:
-            path: ./artifact
-  
+      - checkout
+      - restore_cache: *restore_cache
+      - run: *install
+      - run: npm pack
+      - run:
+          name: Staging artifact
+          command: |
+            mkdir artifact
+            find . -name "*.tgz" -type f -exec cp {} ./artifact \;
+      - store_artifacts:
+          path: ./artifact
+
   publish:
     <<: *defaults
     steps:
@@ -149,7 +149,7 @@ workflows:
       - hold: # Requires manual approval in Circle Ci
           type: approval
       - publish:
-          context: 
+          context:
             - IEAT_keys
           filters:
             branches:

--- a/.git2gus/config.json
+++ b/.git2gus/config.json
@@ -1,4 +1,4 @@
 {
-    "productTag": "a1aB00000004Bx8IAE",
-    "defaultBuild": "offcore.tooling.52"
+  "productTag": "a1aB00000004Bx8IAE",
+  "defaultBuild": "offcore.tooling.52"
 }

--- a/sfdx-project.schema.json
+++ b/sfdx-project.schema.json
@@ -5,9 +5,7 @@
   "description": "The properties and shape of the SFDX project",
   "type": "object",
   "additionalProperties": false,
-  "required": [
-    "packageDirectories"
-  ],
+  "required": ["packageDirectories"],
   "properties": {
     "packageDirectories": {
       "title": "Package Directories",
@@ -18,64 +16,22 @@
       "items": {
         "type": "object",
         "dependencies": {
-          "ancestorId": [
-            "package",
-            "versionNumber"
-          ],
-          "ancestorVersion": [
-            "package",
-            "versionNumber"
-          ],
-          "apexTestAccess": [
-            "package",
-            "versionNumber"
-          ],
-          "definitionFile": [
-            "package",
-            "versionNumber"
-          ],
-          "dependencies": [
-            "package",
-            "versionNumber"
-          ],
-          "package": [
-            "versionNumber"
-          ],
-          "postInstallScript": [
-            "package",
-            "versionNumber"
-          ],
-          "postInstallUrl": [
-            "package",
-            "versionNumber"
-          ],
-          "releaseNotesUrl": [
-            "package",
-            "versionNumber"
-          ],
-          "uninstallScript": [
-            "package",
-            "versionNumber"
-          ],
-          "unpackagedMetadata": [
-            "package",
-            "versionNumber"
-          ],
-          "versionDescription": [
-            "package",
-            "versionNumber"
-          ],
-          "versionName": [
-            "package",
-            "versionNumber"
-          ],
-          "versionNumber": [
-            "package"
-          ]
+          "ancestorId": ["package", "versionNumber"],
+          "ancestorVersion": ["package", "versionNumber"],
+          "apexTestAccess": ["package", "versionNumber"],
+          "definitionFile": ["package", "versionNumber"],
+          "dependencies": ["package", "versionNumber"],
+          "package": ["versionNumber"],
+          "postInstallScript": ["package", "versionNumber"],
+          "postInstallUrl": ["package", "versionNumber"],
+          "releaseNotesUrl": ["package", "versionNumber"],
+          "uninstallScript": ["package", "versionNumber"],
+          "unpackagedMetadata": ["package", "versionNumber"],
+          "versionDescription": ["package", "versionNumber"],
+          "versionName": ["package", "versionNumber"],
+          "versionNumber": ["package"]
         },
-        "required": [
-          "path"
-        ],
+        "required": ["path"],
         "additionalProperties": false,
         "properties": {
           "ancestorId": {
@@ -229,9 +185,7 @@
       "description": "To specify dependencies for 2GP within the same Dev Hub, use either the package version alias or a combination of the package name and the version number.",
       "items": {
         "type": "object",
-        "required": [
-          "package"
-        ],
+        "required": ["package"],
         "properties": {
           "package": {
             "type": "string"
@@ -279,9 +233,7 @@
       "type": "object",
       "title": "Unpackaged Metadata",
       "description": "Metadata not meant to be packaged, but deployed when testing packaged metadata",
-      "required": [
-        "path"
-      ],
+      "required": ["path"],
       "properties": {
         "path": {
           "type": "string",


### PR DESCRIPTION
### What does this PR do?
Update the preferred ssh key in the circleci config file. 
I'm not exactly sure what changed to make the pushes to main start failing in circle, but there are def some outdated ssh keys in the job.  I'm attempted to replace the old deploy key with one that I generated that has read/write instead of just read permissions. 

### What issues does this PR fix or reference?
https://github.com/forcedotcom/easywriter/issues/50

### Functionality Before
Failed to push to main on publish job.

### Functionality After
Publish job succeeds. 
