### PR TITLE
feat: adds seedMetadata for package version creation command

### DIFF
--- a/sfdx-project.schema.json
+++ b/sfdx-project.schema.json
@@ -57,6 +57,10 @@
             "package",
             "versionNumber"
           ],
+          "seedMetadata": [
+            "package",
+            "versionNumber"
+          ],
           "uninstallScript": [
             "package",
             "versionNumber"
@@ -120,6 +124,9 @@
           },
           "releaseNotesUrl": {
             "$ref": "#/definitions/packageDirectory.releaseNotesUrl"
+          },
+          "seedMetadata": {
+            "$ref": "#/definitions/packageDirectory.seedMetadata"
           },
           "uninstallScript": {
             "$ref": "#/definitions/packageDirectory.uninstallScript"
@@ -552,6 +559,21 @@
       "type": "string",
       "title": "Post Install Script",
       "description": "The post install script."
+    },
+    "packageDirectory.seedMetadata": {
+      "type": "object",
+      "title": "Seed Metadata",
+      "description": "Metadata not meant to be packaged, but deployed before deploying packaged metadata",
+      "required": [
+        "path"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "title": "Path",
+          "description": "The path name of the package directory containing the seed metadata"
+        }
+      }
     },
     "packageDirectory.uninstallScript": {
       "type": "string",


### PR DESCRIPTION
[clone of PR69]

What does this PR do?
Adds optional seedMetadata to the schema so unpackageable metadata can be pushed to the build org that the packaged metadata depends on, such as StandardValueSets. This is used for the package version create command.

What issues does this PR fix or reference?
@W-12204966@

Functionality Before
SeedMetadata could not be provided in the sfdx-project.json

Functionality After
SeedMetadata can be provided in the sfdx-project.json

<insert gif and/or summary>
