### PR TITLE
Update sfdx-project.json schema to allow properties for permissionset and permissionsetlicense assignment for package metadata

### DIFF
--- a/sfdx-project.schema.json
+++ b/sfdx-project.schema.json
@@ -30,6 +30,10 @@
             "package",
             "versionNumber"
           ],
+          "packageMetadataAccess": [
+            "package",
+            "versionNumber"
+          ],
           "definitionFile": [
             "package",
             "versionNumber"
@@ -683,12 +687,12 @@
             {
               "type": "string",
               "title": "Permission Set String",
-              "description": "The list of permission set to enable while running Apex tests as a string"
+              "description": "The list of permission sets to enable while running Apex tests as a string"
             },
             {
               "type": "array",
               "title": "Permission Set Array",
-              "description": "The list of permission set to enable while running Apex tests as an array",
+              "description": "The list of permission sets to enable while running Apex tests as an array",
               "items": {
                 "type": "string",
                 "title": "Permission Set Name",
@@ -714,6 +718,55 @@
                 "type": "string",
                 "title": "Permission Set Licenses Developer Name",
                 "description": "Name of the permission set to enable while running Apex tests"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "packageDirectory.packageMetadataAccess": {
+      "type": "object",
+      "title": "Package Metadata Access",
+      "description": "Additional access that should be granted to the user while deploying package metadata, available in Salesforce API version 61.0 and above",
+      "properties": {
+        "permissionSets": {
+          "title": "Permission Sets",
+          "description": "The list of permission sets to enable while deploying package metadata",
+          "oneOf": [
+            {
+              "type": "string",
+              "title": "Permission Set String",
+              "description": "The list of permission sets to enable while deploying package metadata as a string"
+            },
+            {
+              "type": "array",
+              "title": "Permission Set Array",
+              "description": "The list of permission sets to enable while deploying package metadata as an array",
+              "items": {
+                "type": "string",
+                "title": "Permission Set Name",
+                "description": "Name of the permission set to enable while deploying package metadata"
+              }
+            }
+          ]
+        },
+        "permissionSetLicenses": {
+          "title": "Permission Set License",
+          "description": "The list of permission sets licenses to enable while deploying package metadata",
+          "oneOf": [
+            {
+              "type": "string",
+              "title": "Permission Set Licenses String",
+              "description": "The list of permission set licenses to enable while deploying package metadata as a string"
+            },
+            {
+              "type": "array",
+              "title": "Permission Set Licenses Array",
+              "description": "The list of permission set licenses to enable while deploying package metadata as an array",
+              "items": {
+                "type": "string",
+                "title": "Permission Set Licenses Developer Name",
+                "description": "Name of the permission set license to enable while deploying package metadata"
               }
             }
           ]

--- a/sfdx-project.schema.json
+++ b/sfdx-project.schema.json
@@ -100,7 +100,7 @@
             "$ref": "#/definitions/packageDirectory.apexTestAccess"
           },
           "packageMetadataAccess": {
-            "$ref": "#/definitions/packageDirectory.apexTestAccess"
+            "$ref": "#/definitions/packageDirectory.packageMetadataAccess"
           },
           "default": {
             "$ref": "#/definitions/packageDirectory.default"

--- a/sfdx-project.schema.json
+++ b/sfdx-project.schema.json
@@ -99,6 +99,9 @@
           "apexTestAccess": {
             "$ref": "#/definitions/packageDirectory.apexTestAccess"
           },
+          "packageMetadataAccess": {
+            "$ref": "#/definitions/packageDirectory.apexTestAccess"
+          },
           "default": {
             "$ref": "#/definitions/packageDirectory.default"
           },


### PR DESCRIPTION
### What does this PR do?
Update sfdx-project.json schema to include permission set and permission set license assignments that allow a user to assign these values to the build org user for a package version create operation.

### What issues does this PR fix or reference?
@W-14842023@

[skip-validate-pr]

### Functionality Before
There was no way to specify permission set and permission set license assignments for the build org user for package metadata when running package version create. These values could only be specified for apex tests.

### Functionality After
package metadata can be assigned via a property in the packageDirectory using a format like:
"packageMetadataAccess": {
	"permissionSets" : [
			"<ps name>"
		],
	"permissionSetLicenses" : [
			"<psl name>"
        ],
},