### PR TITLE
Revert gha changes

### DIFF
--- a/.github/workflows/onRelease.yml
+++ b/.github/workflows/onRelease.yml
@@ -25,9 +25,7 @@ jobs:
     uses: salesforcecli/github-workflows/.github/workflows/npmPublish.yml@main
     needs: [getDistTag]
     with:
-      ctc: true
-      sign: true
+      ctc: false
       tag: ${{ needs.getDistTag.outputs.tag || 'latest' }}
       githubTag: ${{ github.event.release.tag_name || inputs.tag }}
-
     secrets: inherit


### PR DESCRIPTION
### What does this PR do?
Reverts Github Actions changes from #85
Disables signing and ctc

[skip-validate-pr]